### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/gs-spring-core/src/main/java/com/tirthal/learning/xmlconfig/beanwiring/app-container.xml
+++ b/gs-spring-core/src/main/java/com/tirthal/learning/xmlconfig/beanwiring/app-container.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:jee="http://www.springframework.org/schema/jee"
-	xmlns:lang="http://www.springframework.org/schema/lang"
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:aop="https://www.springframework.org/schema/aop"
+	xmlns:context="https://www.springframework.org/schema/context"
+	xmlns:jee="https://www.springframework.org/schema/jee"
+	xmlns:lang="https://www.springframework.org/schema/lang"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd
-		http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.1.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xmlns:p="https://www.springframework.org/schema/p"
+	xsi:schemaLocation="https://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd
+		https://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee-3.1.xsd
+		https://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+		https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<!-- CREATING BEANS THROUGH FACTORY METHODS + INSTANTIATE AND DESTROY METHOD CALL -->
 	<bean id="stage" class="com.tirthal.learning.xmlconfig.beanwiring.Stage" factory-method="getInstance" init-method="prepareStage" destroy-method="closedToPerform"></bean>

--- a/gs-spring-core/src/main/java/com/tirthal/learning/xmlconfig/spel/app-container.xml
+++ b/gs-spring-core/src/main/java/com/tirthal/learning/xmlconfig/spel/app-container.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:jee="http://www.springframework.org/schema/jee"
-	xmlns:lang="http://www.springframework.org/schema/lang"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd
-		http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.1.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:aop="https://www.springframework.org/schema/aop"
+	xmlns:context="https://www.springframework.org/schema/context"
+	xmlns:jee="https://www.springframework.org/schema/jee"
+	xmlns:lang="https://www.springframework.org/schema/lang"
+	xmlns:util="https://www.springframework.org/schema/util"
+	xmlns:p="https://www.springframework.org/schema/p"
+	xsi:schemaLocation="https://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd
+		https://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee-3.1.xsd
+		https://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+		https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<util:list id="allBooksList">
 		<bean class="com.tirthal.learning.xmlconfig.spel.Book" p:id="101" p:name="Java 8 Learning Made Easy" p:tag="Java" />


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists.  Similar to https://github.com/tirthalpatel/Learning-Spring/pull/1

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).